### PR TITLE
Update Rule.php to get rid of PHP Warning Message

### DIFF
--- a/src/Options/Rule.php
+++ b/src/Options/Rule.php
@@ -53,7 +53,7 @@ abstract class Rule
 
     protected function regexify($pattern)
     {
-        if (@preg_match($pattern, null) === false) {
+        if ('/' !== mb_substr($pattern, 1) && '/' !== mb_substr($pattern, -1)) {
             return '/^' . preg_quote($pattern, '/') . '$/';
         }
 


### PR DESCRIPTION
`PHP Warning:  preg_match(): Delimiter must not be alphanumeric or backslash in .../vendor/lorisleiva/laravel-search-string/src/Options/Rule.php on line 56`

Since we are only trying to check if the specified `$pattern` is wrapped within regex delimiters we could use `mb_substr()` instead of supressing the output of `preg_match()` when invalid delimiters are supplied.