### PR TITLE
Update rule.php

### DIFF
--- a/src/Options/Rule.php
+++ b/src/Options/Rule.php
@@ -53,11 +53,12 @@ abstract class Rule
 
     protected function regexify($pattern)
     {
-        if (@preg_match($pattern, null) === false) {
+        try {
+            preg_match($pattern, null);
+            return $pattern;
+        } catch (\Throwable $exception) {
             return '/^' . preg_quote($pattern, '/') . '$/';
         }
-
-        return $pattern;
     }
 
     public function __toString()


### PR DESCRIPTION
This should handle `preg_match` erroring out when an invalid regex is passed withouth surpressing error messages with `@`.