### PR TITLE
Add LIKE search for specific field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 .phpunit.result.cache
+.idea/

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -55,12 +55,12 @@ class Parser
             case 'T_NOT':
                 $this->nextWithout('T_SPACE');
 
-                if (! $expression = $this->parseExpression()) {
+                if (!$expression = $this->parseExpression()) {
                     throw $this->expectedAnythingBut('T_RPARENT', 'T_EOL');
                 }
 
                 return new NotSymbol($expression);
-            
+
             default:
                 $this->skip('T_SPACE');
                 return $this->parseExpression();
@@ -80,7 +80,7 @@ class Parser
                 $this->next();
                 return new SoloSymbol($content);
 
-            case 'T_LPARENT': 
+            case 'T_LPARENT':
                 $this->next();
                 $expression = $this->parseOr();
                 $this->expect('T_RPARENT');
@@ -89,8 +89,8 @@ class Parser
 
             case 'T_NOT':
                 return $this->parseNot();
-            
-            case 'T_RPARENT': 
+
+            case 'T_RPARENT':
             case 'T_EOL':
             default:
                 return false;
@@ -117,7 +117,7 @@ class Parser
                 $this->expect('T_RPARENT');
                 $this->next();
                 return $expression;
-            
+
             case 'T_LIST_SEPARATOR':
                 throw $this->expectedAnythingBut('T_LIST_SEPARATOR');
 
@@ -134,10 +134,16 @@ class Parser
                 $value = $this->parseEndValue();
                 $this->nextWithout('T_SPACE');
 
-                return $this->current()->hasType('T_LIST_SEPARATOR')
-                    ? $this->parseArrayQuery($key, $operator, [$value])
-                    : new QuerySymbol($key, $operator, $value);
-            
+                if ($this->current()->hasType('T_LIST_SEPARATOR')) {
+                    return $this->parseArrayQuery($key, $operator, [$value]);
+                } else {
+                    if (preg_match('/%/', $value)) {
+                        $operator = 'LIKE';
+                    }
+
+                    return new QuerySymbol($key, $operator, $value);
+                }
+
             default:
                 throw $this->expected('T_TERM', 'T_STRING');
         }
@@ -158,7 +164,7 @@ class Parser
             case 'T_LIST_SEPARATOR':
                 $this->nextWithout('T_SPACE');
                 return $this->parseArrayQuery($key, $operator, $accumulator);
-                
+
             default:
                 return new QuerySymbol($key, $operator, $accumulator);
         }
@@ -168,7 +174,7 @@ class Parser
     {
         $token = $token ?? $this->current();
         return $token->hasType('T_STRING')
-            ? substr($token->content, 1, -1) 
+            ? substr($token->content, 1, -1)
             : $token->content;
     }
 
@@ -199,7 +205,7 @@ class Parser
 
     protected function expect(...$expected)
     {
-        if (! $this->current()->hasType(...$expected)) {
+        if (!$this->current()->hasType(...$expected)) {
             throw $this->expected(...$expected);
         }
     }


### PR DESCRIPTION
Adding a % sign to the string/term in a "Exact match" search will change the operator to LIKE instead of =.  This allows to do a search with wildcard on a specific field instead of relying on the "searchable" option.