### PR TITLE
Qualified columns

### DIFF
--- a/src/Visitors/BuildKeywordsVisitor.php
+++ b/src/Visitors/BuildKeywordsVisitor.php
@@ -83,7 +83,8 @@ class BuildKeywordsVisitor extends Visitor
         Collection::wrap($values)->each(function ($value) {
             $desc = Str::startsWith($value, '-') ? 'desc' : 'asc';
             $column = Str::startsWith($value, '-') ? Str::after($value, '-') : $value;
-            $this->builder->orderBy($column, $desc);
+            $qualifiedColumn = $this->builder->qualifyColumn($column);
+            $this->builder->orderBy($qualifiedColumn, $desc);
         });
     }
 


### PR DESCRIPTION
I've qualified columns by adding table name as prefix. Otherwise, queries like the following will fail.

```sql
Illuminate\Database\QueryException
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'name' in where clause is ambiguous (SQL: select count(*) as aggregate from `rhj_items` inner join `rhj_categories` on `rhj_categories`.`id` = `rhj_items`.`category_id` where (`name` like %test% or `description` like %test%) and `rhj_items`.`deleted_at` is null and `rhj_items`.`company_id` = 1)
```

Feel free to edit if I'm missing anything.