### PR TITLE
Added one more builder group by

### DIFF
--- a/src/Options/SearchStringOptions.php
+++ b/src/Options/SearchStringOptions.php
@@ -20,6 +20,7 @@ trait SearchStringOptions
             'select' => 'fields',
             'limit' => 'limit',
             'offset' => 'from',
+            'group_by' => 'unique',
         ],
     ];
 

--- a/src/Visitors/BuildKeywordsVisitor.php
+++ b/src/Visitors/BuildKeywordsVisitor.php
@@ -49,6 +49,9 @@ class BuildKeywordsVisitor extends Visitor
             case 'offset':
                 $this->buildOffset($query->value);
                 break;
+            case 'group_by':
+                $this->buildGroupBy($query->value);
+                break;
         }
 
         return $query;
@@ -71,6 +74,9 @@ class BuildKeywordsVisitor extends Visitor
                 throw InvalidSearchStringException::fromVisitor('The limit must be an integer');
             case 'offset':
                 throw InvalidSearchStringException::fromVisitor('The offset must be an integer');
+            case 'group_by':
+                $this->buildGroupBy($list->values);
+                break;
         }
 
         return $list;
@@ -86,6 +92,18 @@ class BuildKeywordsVisitor extends Visitor
             $column = $this->manager->getColumnNameFromAlias($column);
             $qualifiedColumn = SearchStringManager::qualifyColumn($this->builder, $column);
             $this->builder->orderBy($qualifiedColumn, $desc);
+        });
+    }
+
+    protected function buildGroupBy($values)
+    {   
+        $this->builder->getQuery()->groups = null;
+        
+        Collection::wrap($values)->each(function ($value) {
+            $column = $value;
+            $column = $this->manager->getColumnNameFromAlias($column);
+            $qualifiedColumn = SearchStringManager::qualifyColumn($this->builder, $column);
+            $this->builder->groupBy($qualifiedColumn);
         });
     }
 

--- a/src/config.php
+++ b/src/config.php
@@ -32,6 +32,7 @@ return [
             'select' => 'fields',
             'limit' => 'limit',
             'offset' => 'from',
+            'group_by' => 'unique',
         ],
     ],
 ];


### PR DESCRIPTION
### Implemented Group By

This implementation will help to do **Group By** in builder using keyword **unique**

When user will write unique:column_name,column_name in search string then group by append to query. 

### Example
title:"My blog article" or not published sort:-created_at unique:customers

`Article::usingSearchString('title:"My blog article" or not published sort:-created_at unique:customers');`

`// Equivalent to:
Article::where('title', 'My blog article')
       ->orWhere('published', false)
       ->orderBy('created_at', 'desc')
       ->groupBy('customers');`