### PR TITLE
Add support for Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ["8.0", "8.1"]
-        laravel: ["^8.0", "^9.0"]
+        php: ["8.0", "8.1", "8.2"]
+        laravel: ["^9.0", "^10.0"]
         include:
-          - laravel: "^8.0"
-            testbench: "^6.0"
           - laravel: "^9.0"
             testbench: "^7.0"
+          - laravel: "^10.0"
+            testbench: "^8.0"
     name: Laravel ${{ matrix.laravel }} PHP${{ matrix.php }} on ${{ matrix.os }}
     container:
       image: lorisleiva/laravel-docker:${{ matrix.php }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ["8.0", "8.1", "8.2"]
+        php: ["8.1", "8.2"]
         laravel: ["^9.0", "^10.0"]
         include:
           - laravel: "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,13 @@
         }
     ],
     "require": {
-        "illuminate/support": "^8.0|^9.0",
+        "illuminate/support": "^9.0|^10.0",
         "hoa/compiler": "^3.17",
         "sanmai/hoa-protocol": "^1.17"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0"
+        "phpunit/phpunit": "^9.0",
+        "orchestra/testbench": "^7.0|^8.0"
     },
     "autoload": {
        "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": "^8.1",
         "illuminate/support": "^9.0|^10.0",
         "hoa/compiler": "^3.17",
         "sanmai/hoa-protocol": "^1.17"

--- a/tests/Concerns/DumpsWhereClauses.php
+++ b/tests/Concerns/DumpsWhereClauses.php
@@ -4,6 +4,7 @@ namespace Lorisleiva\LaravelSearchString\Tests\Concerns;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
 trait DumpsWhereClauses
@@ -27,7 +28,7 @@ trait DumpsWhereClauses
                 return [$key => $children];
             }
 
-            $column = $where->column instanceof \Illuminate\Database\Query\Expression
+            $column = $where->column instanceof Expression
                 ? $where->column->getValue(new MySqlGrammar())
                 : $where->column;
 

--- a/tests/Concerns/DumpsWhereClauses.php
+++ b/tests/Concerns/DumpsWhereClauses.php
@@ -4,6 +4,7 @@ namespace Lorisleiva\LaravelSearchString\Tests\Concerns;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
 trait DumpsWhereClauses
 {
@@ -26,11 +27,16 @@ trait DumpsWhereClauses
                 return [$key => $children];
             }
 
+            $column = $where->column instanceof \Illuminate\Database\Query\Expression
+                ? $where->column->getValue(new MySqlGrammar())
+                : $where->column;
+
             $value = $where->value ?? $where->values ?? null;
             $value = is_array($value) ? ('[' . implode(', ', $value) . ']') : $value;
             $value = is_bool($value) ? ($value ? 'true' : 'false') : $value;
             $value = isset($where->operator) ? "$where->operator $value" : $value;
-            return [$key => is_null($value) ? $where->column : "$where->column $value"];
+
+            return [$key => is_null($value) ? $column : "$column $value"];
         })->toArray();
     }
 

--- a/tests/SearchStringOptionsTest.php
+++ b/tests/SearchStringOptionsTest.php
@@ -115,16 +115,6 @@ class SearchStringOptionsTest extends TestCase
         $this->assertColumnsRulesFor($model, [
             'published_at' => '[/^published_at$/][boolean][date]',
         ]);
-
-        // Added to dates
-        $model = new class extends Model {
-            use SearchString;
-            protected $dates = ['published_at'];
-            protected $searchStringColumns = ['published_at'];
-        };
-        $this->assertColumnsRulesFor($model, [
-            'published_at' => '[/^published_at$/][boolean][date]',
-        ]);
     }
 
     /** @test */


### PR DESCRIPTION
- Adds support for Laravel 10
- Drops support for Laravel 8
- Add testing for PHP 8.2
- Drops support for PHP 8.1
- Dropped the `$dates` test as that is deprecated in Laravel 9, removed in Laravel 10
- Kept PHPUnit 9 for now, as many tests fail with PHPUnit 10. Laravel 10 supports both 9 and 10.